### PR TITLE
Development

### DIFF
--- a/blueprints/user/resources.py
+++ b/blueprints/user/resources.py
@@ -79,14 +79,15 @@ class UserSignUp(Resource):
 
             try:
                 db.session.add(user)
+
+                ##adding new user detail/info
+                #should be inside try, to catch duplicate error and produce 409s
+                user_id = Users.query.filter_by(username=args['username']).first().user_id
+                user_detail = UsersDetail(user_id,user_id)
+                db.session.add(user_detail)
             except:
                 return {'status':'failed','message':'conflicting database'}, 409, {'Content-Type':'application/json'}
             app.logger.debug('DEBUG : %s', user)
-
-            ##adding new user detail/info
-            user_id = Users.query.filter_by(username=args['username']).first().user_id
-            user_detail = UsersDetail(user_id,user_id)
-            db.session.add(user_detail)
 
             db.session.commit()
 


### PR DESCRIPTION
fixed.

by request of mba Ulfah.

then:
- duplicate register produces 500, uncatched adding user_details
now:
- properly return 409 status code. ready to be used by FE.