### PR TITLE
Development

### DIFF
--- a/blueprints/posting/model.py
+++ b/blueprints/posting/model.py
@@ -54,8 +54,9 @@ class TopLevels(db.Model):
 class SecondLevels(db.Model):
     __tablename__ = "second_level"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    user_id = user_id = db.Column(db.Integer, db.ForeignKey('user.user_id'), nullable=False)
-    title = db.Column(db.String(255), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.user_id'), nullable=False)
+    parent_id = db.Column(db.Integer, db.ForeignKey('top_level.id'), nullable=False)
+    #no title
     #content type -- either comment or answer
     content_type = db.Column(db.String(30), nullable=False) 
     html_content = db.Column(db.Text, nullable=False)
@@ -76,7 +77,7 @@ class SecondLevels(db.Model):
     response_fields = {
         'id': fields.Integer,
         'user_id': fields.Integer,
-        'title': fields.String,
+        'parent_id': fields.Integer,
         'content_type': fields.String,
         'html_content': fields.String,
         'content_status': fields.Integer,
@@ -85,9 +86,9 @@ class SecondLevels(db.Model):
         'updated_at': fields.String
     }
 
-    def __init__(self, user_id, title, content_type, html_content):
+    def __init__(self, user_id, parent_id, content_type, html_content):
         self.user_id = user_id
-        self.title = title
+        self.parent_id = parent_id
         self.content_type = content_type
         self.html_content = html_content
         self.content_status = 0

--- a/blueprints/posting/model.py
+++ b/blueprints/posting/model.py
@@ -50,3 +50,49 @@ class TopLevels(db.Model):
         return '<Top Level %r>' % self.title
 
 
+
+class SecondLevels(db.Model):
+    __tablename__ = "second_level"
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = user_id = db.Column(db.Integer, db.ForeignKey('user.user_id'), nullable=False)
+    title = db.Column(db.String(255), nullable=False)
+    #content type -- either comment or answer
+    content_type = db.Column(db.String(30), nullable=False) 
+    html_content = db.Column(db.Text, nullable=False)
+    #no banner
+    #no views
+    # status should merged into one? 0 - normal, 2 - deleted? should c/a be deletable?
+    # deleted = db.Column(db.Boolean, nullable=False)
+    # closed = db.Column(db.Boolean, nullable=False)
+    content_status = db.Column(db.SmallInteger, nullable=False)
+    point = db.Column(db.Integer, nullable=False)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+    #editable?
+    updated_at = db.Column(db.DateTime, server_onupdate=db.func.now())
+
+
+
+    #sementara, html_content di output dalam bentuk string
+    response_fields = {
+        'id': fields.Integer,
+        'user_id': fields.Integer,
+        'title': fields.String,
+        'content_type': fields.String,
+        'html_content': fields.String,
+        'content_status': fields.Integer,
+        'point': fields.Integer,
+        'created_at': fields.String,
+        'updated_at': fields.String
+    }
+
+    def __init__(self, user_id, title, content_type, html_content):
+        self.user_id = user_id
+        self.title = title
+        self.content_type = content_type
+        self.html_content = html_content
+        self.content_status = 0
+        self.point = 0
+        #no kwargs for banner
+
+    def __repr__(self):
+        return '<Second Level %r>' % self.title


### PR DESCRIPTION
done:
- POST /posting/secondlevel/<:id> now avaiable, only need html_content and content_type ('answer','comment')
NOTE: building the BE this way seems to be a bit weird. id in the url_path for posting correspond to toplevel posting's id, but later in PUT statement would refer to the secondlevel's id.

- in GET /posting/toplevel/<:id> , now returns list/array of secondlevel posting that correspondent with its own id

- GET toplevel would also put user_data inside the list/array of secondlevel for each entry.
-- next time, the mini profile should also contain a direct identifier (either leave it as username or add user_id in the returns)