### PR TITLE
Hotfix/werkzeug

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,9 +4,9 @@ import logging, sys
 from logging.handlers import RotatingFileHandler
 
 
-from werkzeug.contrib.cache import SimpleCache
+# from werkzeug.contrib.cache import SimpleCache
 
-cache = SimpleCache()
+# cache = SimpleCache()
 
 api = Api(app, catch_all_404s=True)
 


### PR DESCRIPTION
CHAOS.

werkzeug got an update.
https://palletsprojects.com/blog/werkzeug-1-0-0-released/
caused pip install requirement in flask to 
removed simplecache for now. have to rework for testing (per mas Setyo)